### PR TITLE
Fix: 0 assumed for stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"golang.org/x/crypto/scrypt"
 	"golang.org/x/crypto/ssh/terminal"
@@ -125,7 +126,7 @@ func GetMasterPassword() ([]byte, error) {
 	//prompt is written to stderr because pwget may be used in a pipe where the
 	//password is read from stdout by the next program (e.g. xsel or xclip)
 	os.Stderr.Write([]byte("Master password: "))
-	result, err := terminal.ReadPassword(0)
+	result, err := terminal.ReadPassword(int(syscall.Stdin))
 	os.Stderr.Write([]byte("\n"))
 	return result, err
 }


### PR DESCRIPTION
I am usually not in favor of tweaking free software to work better with Windows. But in this case I nonetheless find it more clean to not assume a fd for stdin.

Nitpicking, maybe. But actually I am using pwget on windows. Forgive me.