### PR TITLE
Increase entropy for shortened passwords

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,13 +44,27 @@ func main() {
 	masterPassword, err := GetMasterPassword()
 	FailOnError("password query", err)
 
+	//make character space for later mapping
+	charSpace := "_-0123456789"
+	var offset byte
+	for offset = 0; offset < 26; offset++ {
+		charSpace += string('A' + offset)
+		charSpace += string('a' + offset)
+	}
+
 	//now we're all set, derive the password
 	var passwordStr, hashStr string
 	for iteration := 0; true; iteration++ {
 		//get the password for this iteration
 		salt := []byte(strconv.Itoa(iteration) + ":" + domain)
 		password := Scrypt(masterPassword, salt)
-		passwordStr = hex.EncodeToString(password)
+
+		// map password to character space
+		passwordStr = ""
+		for _, b := range password {
+			charIndex := int(b) % len(charSpace)
+			passwordStr += string(charSpace[charIndex])
+		}
 
 		//this is the correct password, unless it has been revoked
 		hash := sha256.Sum256([]byte(passwordStr))


### PR DESCRIPTION
While thinking about how to implement domain properties, it occurred to me that in many cases a generated password has to be shortened in order to comply with a system which sets a limit to the password length. I found it an important aspect to keep as much entropy as possible when shortening a password.
Since many systems (domains) enforce a maximum password length, the functionality introduced in this PR will be beneficial to the domain properties functionality that is going to be introduced in another PR soon.

The technical details:
The entropy of a password generated by `Scrypt` is `ln( 256^32 )/ln(2) = 256` bits. This entropy doesn't change after hexifying the password.
The approach is to map each character of the password to a character out of the character space\
`[A-Za-z0-9_-]`, which contains 64 characters.
The new entropy then is: `ln( 64^32 )/ln(2) = 192` bits – still very high.

The benefit gets clear when shortening a password, in this example to 12 characters:
Shortening a hexified password would yield an entropy of `ln( 16^12 )/ln(2) = 48` bits.
Shortening a mapped password does yield a new entropy of `ln( 64^12 )/ln(2) = 72` bits.