### PR TITLE
Domain properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ hash of every revoked password. pwget will always show a list of all revoked
 passwords that it encounters, so you can recover from an undesired revocation
 easily.
 
+Many systems enforce some sort of password policy, e.&nbsp;g. the password must
+contain at least one upper-case character, at least one digit, etc.
+To avoid the necessity of tweaking a pwget-generated password in order to be
+able to use it on such a system, pwget has the following command line switches
+that influence the password generation:
+- `[ -l | --maxlength ] <max_len>`: The generated password will have a length of `max_len` characters at most
+- `-A | --upper`: The generated password will contain at least one upper-case letter
+- `-a | --lower`: The generated password will contain at least one lower-case letter
+- `-s | --special`: The generated password will contain at least one special character
+- `-d | --digit`: The generated password will contain at least one digit
+
 ## Algorithm
 
 In pseudo-code:

--- a/main.go
+++ b/main.go
@@ -148,7 +148,8 @@ func ParseArguments() (domain string, revoke bool, maxLen int, upper bool, lower
 	}
 
 	if len(pflag.Args()) <= 0 || help {
-		os.Stderr.Write([]byte("Usage: " + os.Args[0] + " [-r|--revoke] [-l|--maxlength <max_len>] <domain>\n"))
+		os.Stderr.Write([]byte("Usage:\t" + os.Args[0] + " [-r|--revoke] [-l|--maxlength <max_len>] [-A|--upper] [-a|--lower] [-d|--digit] [-s|--special] <domain>\n"))
+		pflag.PrintDefaults();
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 
 func main() {
 	//check arguments
-	domain, doRevoke, maxLen, needsUpper, needsLower, needsSpecial, needsNumber := ParseArguments()
+	domain, doRevoke, maxLen, needsUpper, needsLower, needsSpecial, needsDigit := ParseArguments()
 
 	//load revocation list
 	isSHA256OfRevokedPassword, err := LoadRevocationList()
@@ -89,7 +89,7 @@ func main() {
 		if needsSpecial {
 			includeInPassword(password, &offset, "[_\\-]", '-')
 		}
-		if needsNumber {
+		if needsDigit {
 			includeInPassword(password, &offset, "[0-9]", '0')
 		}
 
@@ -122,7 +122,7 @@ func FailOnError(operation string, err error) {
 }
 
 //ParseArguments parses the os.Args. Will not return if they are malformed.
-func ParseArguments() (domain string, revoke bool, maxLen int, upper bool, lower bool, special bool, number bool) {
+func ParseArguments() (domain string, revoke bool, maxLen int, upper bool, lower bool, special bool, digit bool) {
 
 	//define flags
 	var help bool
@@ -130,8 +130,8 @@ func ParseArguments() (domain string, revoke bool, maxLen int, upper bool, lower
 	pflag.BoolVarP(&help, "help", "h", false, "Show information on program usage")
 	pflag.BoolVarP(&upper, "upper", "A", false, "Generated password will contain a upper-case character")
 	pflag.BoolVarP(&lower, "lower", "a", false, "Generated password will contain a lower-case character")
-	pflag.BoolVarP(&special, "special", "s", false, "Generated password will contain the special character '!'")
-	pflag.BoolVarP(&number, "number", "n", false, "Generated password will contain a number")
+	pflag.BoolVarP(&special, "special", "s", false, "Generated password will contain the special character '-'")
+	pflag.BoolVarP(&digit, "digit", "d", false, "Generated password will contain a digit")
 	pflag.IntVarP(&maxLen, "maxlength", "l", 0, "Maximum length to which the generated password will be shortened. 0 means don't shorten.")
 
 	//parse and check flags
@@ -153,7 +153,7 @@ func ParseArguments() (domain string, revoke bool, maxLen int, upper bool, lower
 	}
 
 	domain = pflag.Args()[0]
-	return domain, revoke, maxLen, upper, lower, special, number
+	return domain, revoke, maxLen, upper, lower, special, digit
 }
 
 //GetMasterPassword queries the user for the master password.


### PR DESCRIPTION
This should suffice for getting rid of the need for manually editing a generated password.
The implemented properties a domain can have are:
- Maximum password length: `-l <max_len> | --length <max_len>`
- Password must contain upper-case letters: `-A | --upper`
- Password must contain lower-case letters: `-a | --lower`
- Password must contain special characters: `-s | --special`
- Password must contain numbers: `-n | --number`

Arguments can be grouped, e. g.: `pwget <domain_name> -Aasnl12`