### PR TITLE
Print hash instead of cleartext when showing revoked password

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		hash := sha256.Sum256([]byte(passwordStr))
 		hashStr = z85EncodeToString(hash[:])
 		if isSHA256OfRevokedPassword[hashStr] {
-			os.Stderr.Write([]byte("\x1B[37m" + hashStr + " is revoked\x1B[0m\n"))
+			os.Stderr.Write([]byte("\x1B[37mhash:" + hashStr + " is revoked\x1B[0m\n"))
 			continue
 		}
 		break
@@ -64,7 +64,7 @@ func main() {
 
 	//now, we either print or revoke the thing
 	if doRevoke {
-		os.Stderr.Write([]byte("Revoking " + hashStr + "\n"))
+		os.Stderr.Write([]byte("Revoking hash:" + hashStr + "\n"))
 		err := AppendToRevocationList(hashStr)
 		FailOnError("update revocation list", err)
 	} else {

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		hash := sha256.Sum256([]byte(passwordStr))
 		hashStr = z85EncodeToString(hash[:])
 		if isSHA256OfRevokedPassword[hashStr] {
-			os.Stderr.Write([]byte("\x1B[37m" + passwordStr + " is revoked\x1B[0m\n"))
+			os.Stderr.Write([]byte("\x1B[37m" + hashStr + " is revoked\x1B[0m\n"))
 			continue
 		}
 		break
@@ -64,7 +64,7 @@ func main() {
 
 	//now, we either print or revoke the thing
 	if doRevoke {
-		os.Stderr.Write([]byte("Revoking " + passwordStr + "\n"))
+		os.Stderr.Write([]byte("Revoking " + hashStr + "\n"))
 		err := AppendToRevocationList(hashStr)
 		FailOnError("update revocation list", err)
 	} else {


### PR DESCRIPTION
When generating a password the revoked passwords which are skipped are printed in cleartext, and not their hashes (as they appear in the revocation list). I thought this was by design, but when I mentioned it to you, you acted mildly surprised.

On one hand one never sees the cleartext password that is being revoked, on the other hand it is easy to see which hashes in the revocation list belong to which domain.

Merge it if you will :)