### PR TITLE
Read password from stdin if it is not a terminal

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,11 @@ func ParseArguments() (domain string, length int, revoke bool) {
 
 //GetMasterPassword queries the user for the master password.
 func GetMasterPassword() ([]byte, error) {
+	// read password from stdin if stdin is not a terminal
+	if !terminal.IsTerminal(syscall.Stdin) {
+		return ioutil.ReadAll(os.Stdin)
+	}
+
 	//prompt is written to stderr because pwget may be used in a pipe where the
 	//password is read from stdout by the next program (e.g. xsel or xclip)
 	os.Stderr.Write([]byte("Master password: "))


### PR DESCRIPTION
When calling pwget from a wrapper program, the master password cannot be typed in because stdin is not a terminal. In this case it is necessary to provide the password via stdin.

Possible alternatives:
- I guess it is possible to redirect the wrapper's stdin to the stdin of the subprocess (pwget), but then all terminal control sequences have to be redirected to the terminal too, though the generated password has to be obtained... If I didn't miss a possible simple way of doing all that, this is unnecessarily complicated.
- Force a pwget 'wrapper' programs to be called in a pipeline after pwget like it's done up to now with [xkcdget](https://github.com/hkgit03/xkcdget). This is not as simple to use as calling the wrapper program directly, which in turn calls pwget.